### PR TITLE
ai/trashdig: integrate MCP tools via ADK McpToolset

### DIFF
--- a/AI/trashdig/TODO.md
+++ b/AI/trashdig/TODO.md
@@ -113,9 +113,10 @@
     - [ ] Assess overlap with existing `ProjectDatabase` — may be redundant.
 
 ### Tool Ecosystem
-- [ ] **[MEDIUM]** Integrate MCP (Model Context Protocol) tools via ADK's native MCP support.
-    - [ ] Evaluate existing security-focused MCP servers (e.g., static analysis, CVE lookup) as drop-in tools.
-    - [ ] See ADK docs: `docs/mcp/index.md` and `docs/tools/mcp-tools.md`.
+- [x] **[MEDIUM]** Integrate MCP (Model Context Protocol) tools via ADK's native MCP support.
+    - [x] Evaluate existing security-focused MCP servers (e.g., static analysis, CVE lookup) as drop-in tools.
+    - [x] See ADK docs: `docs/mcp/index.md` and `docs/tools/mcp-tools.md`.
+    - [x] Implemented: `McpServerConfig` in `config.py`, `tools/mcp_toolsets.py` factory, `extra_tools` on all agent factories, wired in `Coordinator`. Configure via `[[mcp_servers]]` in `trashdig.toml`.
 - [ ] **[LOW]** Use ADK OpenAPI tool generation for third-party security APIs.
     - [ ] Candidates: NVD/CVE API, bug bounty platform APIs (HackerOne, Bugcrowd), GitHub Security Advisory API.
     - [ ] See ADK docs: `docs/tools/openapi-tools.md`.

--- a/AI/trashdig/src/trashdig/agents/coordinator.py
+++ b/AI/trashdig/src/trashdig/agents/coordinator.py
@@ -34,6 +34,7 @@ from trashdig.tools import (
     save_hypotheses,
     update_hypothesis_status,
 )
+from trashdig.tools.mcp_toolsets import build_mcp_toolsets
 
 logger = logging.getLogger(__name__)
 
@@ -85,22 +86,27 @@ class Coordinator(LlmAgent):
         stack_scout = create_stack_scout_agent(
             config.get_agent_config("stack_scout") or config.get_agent_config("archaeologist"),
             permission_manager=perm,
+            extra_tools=build_mcp_toolsets(config, "stack_scout"),
         )
         web_route_mapper = create_web_route_mapper_agent(
             config.get_agent_config("web_route_mapper"),
             permission_manager=perm,
+            extra_tools=build_mcp_toolsets(config, "web_route_mapper"),
         )
         hunter = create_hunter_agent(
             config.get_agent_config("hunter"),
             permission_manager=perm,
+            extra_tools=build_mcp_toolsets(config, "hunter"),
         )
         skeptic = create_skeptic_agent(
             config.get_agent_config("skeptic"),
             permission_manager=perm,
+            extra_tools=build_mcp_toolsets(config, "skeptic"),
         )
         validator = create_validator_agent(
             config.get_agent_config("validator"),
             permission_manager=perm,
+            extra_tools=build_mcp_toolsets(config, "validator"),
         )
 
         db_path = getattr(config, "db_path", ".trashdig/trashdig.db")

--- a/AI/trashdig/src/trashdig/agents/coordinator.py
+++ b/AI/trashdig/src/trashdig/agents/coordinator.py
@@ -51,6 +51,7 @@ class Coordinator(LlmAgent):
     # ------------------------------------------------------------------
     # All mutable state
     # ------------------------------------------------------------------
+    _config: Config = PrivateAttr()
     _db: ProjectDatabase = PrivateAttr()
     _session_service: BaseSessionService = PrivateAttr()
     _artifact_service: BaseArtifactService | None = PrivateAttr()
@@ -150,6 +151,7 @@ class Coordinator(LlmAgent):
 
         cost_tracker = CostTracker()
 
+        object.__setattr__(self, "_config", config)
         object.__setattr__(self, "_db", db)
         object.__setattr__(self, "_session_service", session_service)
         object.__setattr__(self, "_artifact_service", artifact_service)
@@ -172,6 +174,11 @@ class Coordinator(LlmAgent):
     # ------------------------------------------------------------------
     # TUI compatibility properties (read-only)
     # ------------------------------------------------------------------
+
+    @property
+    def config(self) -> Config:
+        """Returns the TrashDig configuration."""
+        return self._config
 
     @property
     def project_path(self) -> str:
@@ -385,6 +392,7 @@ class Coordinator(LlmAgent):
 
     async def run_full_scan(self, path: str = ".") -> None:
         """Run the full SCAN → HUNT → VERIFY pipeline with hypothesis loop."""
+        TrashDigCallback.get_instance().reset_turn_counts()
         # Phase 1: Recon
         await self.run_recon(path)
 
@@ -464,6 +472,7 @@ class Coordinator(LlmAgent):
 
     async def run_recon(self, path: str = ".") -> dict[str, Any]:
         """Performs initial stack discovery and project mapping."""
+        TrashDigCallback.get_instance().reset_turn_counts()
         self.log(f"[bold]Coordinator:[/bold] starting reconnaissance on [cyan]{path}[/cyan]")
 
         abs_path = os.path.abspath(path)  # noqa: ASYNC240
@@ -537,6 +546,7 @@ class Coordinator(LlmAgent):
         Returns:
             A list of new Finding objects discovered.
         """
+        TrashDigCallback.get_instance().reset_turn_counts()
         new_findings: list[Finding] = []
         for i, target in enumerate(targets, 1):
             self.log(f"[bold]Hunter:[/bold] analysing [cyan]{target}[/cyan] ([dim]{i}/{len(targets)}[/dim])")

--- a/AI/trashdig/src/trashdig/agents/hunter.py
+++ b/AI/trashdig/src/trashdig/agents/hunter.py
@@ -32,13 +32,16 @@ class HunterAgent(LlmAgent):
 
 
 def create_hunter_agent(
-    config: AgentConfig | None = None, permission_manager: PermissionManager | None = None
+    config: AgentConfig | None = None,
+    permission_manager: PermissionManager | None = None,
+    extra_tools: list[Any] | None = None,
 ) -> HunterAgent:
     """Creates a Hunter agent.
 
     Args:
         config: Optional agent configuration.
         permission_manager: Optional permission manager.
+        extra_tools: Additional toolsets (e.g. McpToolset instances) to append.
 
     Returns:
         A configured HunterAgent instance.
@@ -72,6 +75,8 @@ def create_hunter_agent(
 
     if permission_manager:
         tools = permission_manager.wrap_tools(tools)
+    if extra_tools:
+        tools.extend(extra_tools)
 
     kwargs = (
         {"generate_content_config": extras["generate_content_config"]}

--- a/AI/trashdig/src/trashdig/agents/recon.py
+++ b/AI/trashdig/src/trashdig/agents/recon.py
@@ -45,12 +45,14 @@ class WebRouteMapperAgent(LlmAgent):
 def create_stack_scout_agent(
     config: AgentConfig | None = None,
     permission_manager: PermissionManager | None = None,
+    extra_tools: list[Any] | None = None,
 ) -> LlmAgent:
     """Creates a StackScout agent for environment and tech stack detection.
 
     Args:
         config: Agent configuration.
         permission_manager: Permission manager for tools.
+        extra_tools: Additional toolsets (e.g. McpToolset instances) to append.
 
     Returns:
         A configured LlmAgent instance.
@@ -79,6 +81,8 @@ def create_stack_scout_agent(
 
     if permission_manager:
         tools = permission_manager.wrap_tools(tools)
+    if extra_tools:
+        tools.extend(extra_tools)
 
     kwargs = {"generate_content_config": extras["generate_content_config"]} if extras["generate_content_config"] else {}
 
@@ -94,12 +98,14 @@ def create_stack_scout_agent(
 def create_web_route_mapper_agent(
     config: AgentConfig | None = None,
     permission_manager: PermissionManager | None = None,
+    extra_tools: list[Any] | None = None,
 ) -> LlmAgent:
     """Creates a WebRouteMapper agent for attack surface discovery.
 
     Args:
         config: Agent configuration.
         permission_manager: Permission manager for tools.
+        extra_tools: Additional toolsets (e.g. McpToolset instances) to append.
 
     Returns:
         A configured LlmAgent instance.
@@ -120,6 +126,8 @@ def create_web_route_mapper_agent(
 
     if permission_manager:
         tools = permission_manager.wrap_tools(tools)
+    if extra_tools:
+        tools.extend(extra_tools)
 
     kwargs = {"generate_content_config": extras["generate_content_config"]} if extras["generate_content_config"] else {}
 

--- a/AI/trashdig/src/trashdig/agents/skeptic.py
+++ b/AI/trashdig/src/trashdig/agents/skeptic.py
@@ -15,7 +15,9 @@ class SkepticAgent(LlmAgent):
 
 
 def create_skeptic_agent(
-    config: AgentConfig | None = None, permission_manager: PermissionManager | None = None
+    config: AgentConfig | None = None,
+    permission_manager: PermissionManager | None = None,
+    extra_tools: list[Any] | None = None,
 ) -> SkepticAgent:
     """Creates a Skeptic agent."""
     if config is None:
@@ -36,6 +38,8 @@ def create_skeptic_agent(
 
     if permission_manager:
         tools = permission_manager.wrap_tools(tools)
+    if extra_tools:
+        tools.extend(extra_tools)
 
     kwargs = (
         {"generate_content_config": extras["generate_content_config"]}

--- a/AI/trashdig/src/trashdig/agents/utils/callbacks.py
+++ b/AI/trashdig/src/trashdig/agents/utils/callbacks.py
@@ -16,6 +16,7 @@ from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.tool_context import ToolContext
+from google.genai import types
 
 from trashdig.agents.utils.types import EngineState
 from trashdig.services.rate_limiter import get_rate_limiter
@@ -47,6 +48,7 @@ class TrashDigCallback:
         """
         self._c = coordinator
         self._last_prompt: str = ""
+        self._turn_counts: dict[str, int] = {}
 
     @classmethod
     def get_instance(cls, coordinator: Coordinator | None = None) -> TrashDigCallback:
@@ -71,6 +73,10 @@ class TrashDigCallback:
     def _reset(cls) -> None:
         """Reset the singleton instance (for testing)."""
         cls._instance = None
+
+    def reset_turn_counts(self) -> None:
+        """Clear per-agent turn counters at the start of a new scan."""
+        self._turn_counts.clear()
 
     def attach_to(self, agent: Any) -> None:
         """Attach this callback manager to an ADK agent.
@@ -128,7 +134,32 @@ class TrashDigCallback:
     # ------------------------------------------------------------------
 
     async def on_before_model(self, ctx: CallbackContext, req: LlmRequest, **kwargs: Any) -> LlmResponse | None:
-        """Capture the prompt and wait for a rate-limit slot."""
+        """Enforce per-agent turn limits, capture prompt, and wait for rate-limit slot."""
+        agent_name = getattr(ctx, "agent_name", None) or "unknown"
+        self._turn_counts[agent_name] = self._turn_counts.get(agent_name, 0) + 1
+        current = self._turn_counts[agent_name]
+
+        max_turns = self._c.config.get_agent_config(agent_name).max_turns
+        if max_turns is not None and current > max_turns:
+            self._c.log(
+                f"[bold red]Turn limit:[/bold red] {agent_name} reached "
+                f"max_turns={max_turns} (turn {current}). Stopping."
+            )
+            logger.warning(
+                "Agent %s exceeded max_turns=%d (turn %d); returning stop response.",
+                agent_name, max_turns, current,
+            )
+            return LlmResponse(
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text=(
+                        f"Turn limit of {max_turns} reached. "
+                        "Stopping and returning control to the coordinator."
+                    ))],
+                ),
+                finish_reason=types.FinishReason.STOP,
+            )
+
         limiter = get_rate_limiter()
         if limiter:
             await limiter.wait_for_request()

--- a/AI/trashdig/src/trashdig/agents/validator.py
+++ b/AI/trashdig/src/trashdig/agents/validator.py
@@ -23,7 +23,9 @@ class ValidatorAgent(LlmAgent):
 
 
 def create_validator_agent(
-    config: AgentConfig | None = None, permission_manager: PermissionManager | None = None
+    config: AgentConfig | None = None,
+    permission_manager: PermissionManager | None = None,
+    extra_tools: list[Any] | None = None,
 ) -> ValidatorAgent:
     """Creates a Validator agent."""
     if config is None:
@@ -46,6 +48,8 @@ def create_validator_agent(
 
     if permission_manager:
         tools = permission_manager.wrap_tools(tools)
+    if extra_tools:
+        tools.extend(extra_tools)
 
     kwargs = (
         {"generate_content_config": extras["generate_content_config"]}

--- a/AI/trashdig/src/trashdig/config.py
+++ b/AI/trashdig/src/trashdig/config.py
@@ -54,6 +54,7 @@ class AgentConfig:
     provider: str = "google"
     temperature: float = 0.0
     max_tokens: int = 4096
+    max_turns: int | None = None
 
 
 @dataclass
@@ -215,6 +216,7 @@ class Config:
             name=agent_name,
             model=cfg_data.get("model", self.default_model),
             provider=cfg_data.get("provider", self.default_provider),
+            max_turns=cfg_data.get("max_turns"),
         )
 
     def get_provider_config(self, provider_name: str) -> ProviderConfig:

--- a/AI/trashdig/src/trashdig/config.py
+++ b/AI/trashdig/src/trashdig/config.py
@@ -4,7 +4,7 @@ import threading
 import tomllib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 
 def _find_user_config() -> str | None:
@@ -27,6 +27,23 @@ class ProviderConfig:
     name: str = "google"
     api_key: str | None = None
     base_url: str | None = None
+
+
+@dataclass
+class McpServerConfig:
+    """Configuration for an external MCP server."""
+    name: str
+    transport: Literal["stdio", "sse", "http"] = "stdio"
+    # stdio params
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    # sse / http params
+    url: str | None = None
+    # common
+    tool_filter: list[str] = field(default_factory=list)
+    agents: list[str] = field(default_factory=list)  # empty → all agents
+    timeout: float | None = None
 
 
 @dataclass
@@ -167,6 +184,24 @@ class Config:
                 model=cfg.get("model", self.default_model),
                 provider=cfg.get("provider", self.default_provider),
             )
+        return result
+
+    @property
+    def mcp_servers(self) -> list[McpServerConfig]:
+        """Returns configured MCP server integrations."""
+        result = []
+        for entry in self.data.get("mcp_servers", []):
+            result.append(McpServerConfig(
+                name=entry["name"],
+                transport=entry.get("transport", "stdio"),
+                command=entry.get("command"),
+                args=entry.get("args", []),
+                env=entry.get("env", {}),
+                url=entry.get("url"),
+                tool_filter=entry.get("tool_filter", []),
+                agents=entry.get("agents", []),
+                timeout=entry.get("timeout"),
+            ))
         return result
 
     def get_agent_config(self, agent_name: str) -> AgentConfig:

--- a/AI/trashdig/src/trashdig/tools/mcp_toolsets.py
+++ b/AI/trashdig/src/trashdig/tools/mcp_toolsets.py
@@ -1,0 +1,81 @@
+"""Factory for building ADK McpToolset instances from TrashDig config."""
+
+import logging
+
+from google.adk.tools.mcp_tool.mcp_session_manager import (
+    SseConnectionParams,
+    StdioConnectionParams,
+    StreamableHTTPConnectionParams,
+)
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+from mcp import StdioServerParameters
+
+from trashdig.config import Config, McpServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+def build_mcp_toolsets(config: Config, agent_name: str) -> list[McpToolset]:
+    """Return McpToolset instances for MCP servers scoped to *agent_name*.
+
+    Servers whose ``agents`` list is empty are given to all agents.  Servers
+    that list specific agent names are only given to those agents.
+    """
+    toolsets = []
+    for srv in config.mcp_servers:
+        if srv.agents and agent_name not in srv.agents:
+            continue
+        toolset = _toolset_from_config(srv)
+        if toolset is not None:
+            toolsets.append(toolset)
+    return toolsets
+
+
+def _toolset_from_config(srv: McpServerConfig) -> McpToolset | None:
+    tool_filter: list[str] | None = srv.tool_filter or None
+
+    try:
+        if srv.transport == "stdio":
+            if not srv.command:
+                logger.error("MCP server %r: stdio transport requires 'command'", srv.name)
+                return None
+            connection_params = StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command=srv.command,
+                    args=srv.args or [],
+                    env=srv.env or None,
+                ),
+                timeout=srv.timeout if srv.timeout is not None else 5.0,
+            )
+
+        elif srv.transport == "sse":
+            if not srv.url:
+                logger.error("MCP server %r: sse transport requires 'url'", srv.name)
+                return None
+            connection_params = SseConnectionParams(
+                url=srv.url,
+                timeout=srv.timeout if srv.timeout is not None else 5.0,
+            )
+
+        elif srv.transport == "http":
+            if not srv.url:
+                logger.error("MCP server %r: http transport requires 'url'", srv.name)
+                return None
+            connection_params = StreamableHTTPConnectionParams(
+                url=srv.url,
+                timeout=srv.timeout if srv.timeout is not None else 5.0,
+            )
+
+        else:
+            logger.error("MCP server %r: unknown transport %r", srv.name, srv.transport)
+            return None
+
+        return McpToolset(
+            connection_params=connection_params,
+            tool_filter=tool_filter,
+            tool_name_prefix=f"mcp_{srv.name}_",
+        )
+
+    except Exception:
+        logger.exception("Failed to build McpToolset for server %r", srv.name)
+        return None

--- a/AI/trashdig/tests/agent_test_utils.py
+++ b/AI/trashdig/tests/agent_test_utils.py
@@ -31,6 +31,7 @@ import trashdig.tools
 # ALL_TOOLS (in test_agent_tools.py) does not need to list them.
 TOOLS_PKG_NON_TOOLS: frozenset[str] = frozenset({
     "artifact_tool",         # decorator applied to tool implementations
+    "build_mcp_toolsets",    # factory for McpToolset instances (not an agent tool)
     "get_artifact_service",  # runtime singleton accessor
     "init_artifact_manager", # one-time initialisation helper
 })

--- a/AI/trashdig/tests/test_callbacks.py
+++ b/AI/trashdig/tests/test_callbacks.py
@@ -10,6 +10,7 @@ from google.adk.tools.base_tool import BaseTool
 from trashdig.agents.coordinator import Coordinator
 from trashdig.agents.utils.callbacks import TrashDigCallback
 from trashdig.agents.utils.types import EngineState
+from trashdig.config import AgentConfig
 
 
 @pytest.fixture(autouse=True)
@@ -17,6 +18,13 @@ def reset_callback_singleton():
     TrashDigCallback._reset()
     yield
     TrashDigCallback._reset()
+
+
+def _make_agent_config(max_turns=None):
+    cfg = MagicMock(spec=AgentConfig)
+    cfg.max_turns = max_turns
+    return cfg
+
 
 @pytest.fixture
 def mock_coordinator():
@@ -27,6 +35,8 @@ def mock_coordinator():
     coord._db = MagicMock()
     coord._cost_tracker = MagicMock()
     coord._state = EngineState.IDLE
+    # Default: no turn limit for any agent
+    coord.config.get_agent_config.return_value = _make_agent_config(max_turns=None)
     # Mock _agent_by_name to return a mock agent with a model
     agent = MagicMock(spec=LlmAgent)
     agent.model = "gemini-2.0-flash"
@@ -122,3 +132,95 @@ def test_callback_agent_lifecycle(mock_coordinator):
 
     cb.on_after_agent(context=ctx, agent=None)
     assert mock_coordinator._state == EngineState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# Turn limit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_turn_limit_not_enforced_when_unset(mock_coordinator):
+    """No turn limit configured → every call proceeds normally."""
+    mock_coordinator.config.get_agent_config.return_value = _make_agent_config(max_turns=None)
+    cb = TrashDigCallback.get_instance(mock_coordinator)
+
+    ctx = MagicMock(spec=CallbackContext)
+    ctx.agent_name = "hunter"
+    req = MagicMock()
+    req.contents = []
+
+    for _ in range(50):
+        result = await cb.on_before_model(ctx, req)
+        assert result is None, "Expected None (no stop) when max_turns is unset"
+
+
+@pytest.mark.anyio
+async def test_turn_limit_allows_up_to_limit(mock_coordinator):
+    """Calls up to max_turns are allowed; the (max_turns+1)-th is blocked."""
+    mock_coordinator.config.get_agent_config.return_value = _make_agent_config(max_turns=3)
+    cb = TrashDigCallback.get_instance(mock_coordinator)
+
+    ctx = MagicMock(spec=CallbackContext)
+    ctx.agent_name = "hunter"
+    req = MagicMock()
+    req.contents = []
+
+    for turn in range(1, 4):
+        result = await cb.on_before_model(ctx, req)
+        assert result is None, f"Turn {turn} should be allowed (max_turns=3)"
+
+    # 4th call must be blocked
+    result = await cb.on_before_model(ctx, req)
+    assert isinstance(result, LlmResponse), "Expected LlmResponse stop on turn 4"
+    assert result.finish_reason == genai_types.FinishReason.STOP
+    assert "3" in result.content.parts[0].text  # limit mentioned in message
+
+
+@pytest.mark.anyio
+async def test_turn_limit_per_agent_independent(mock_coordinator):
+    """Turn counters are tracked independently per agent name."""
+    def _cfg_for(agent_name):
+        return _make_agent_config(max_turns=2)
+
+    mock_coordinator.config.get_agent_config.side_effect = _cfg_for
+    cb = TrashDigCallback.get_instance(mock_coordinator)
+
+    req = MagicMock()
+    req.contents = []
+
+    ctx_a = MagicMock(spec=CallbackContext)
+    ctx_a.agent_name = "hunter"
+    ctx_b = MagicMock(spec=CallbackContext)
+    ctx_b.agent_name = "skeptic"
+
+    # Both agents: first two calls are fine
+    assert await cb.on_before_model(ctx_a, req) is None
+    assert await cb.on_before_model(ctx_b, req) is None
+    assert await cb.on_before_model(ctx_a, req) is None
+    assert await cb.on_before_model(ctx_b, req) is None
+
+    # 3rd call for each is blocked
+    result_a = await cb.on_before_model(ctx_a, req)
+    result_b = await cb.on_before_model(ctx_b, req)
+    assert isinstance(result_a, LlmResponse)
+    assert isinstance(result_b, LlmResponse)
+
+
+@pytest.mark.anyio
+async def test_reset_turn_counts_clears_state(mock_coordinator):
+    """reset_turn_counts() lets agents run again after being blocked."""
+    mock_coordinator.config.get_agent_config.return_value = _make_agent_config(max_turns=1)
+    cb = TrashDigCallback.get_instance(mock_coordinator)
+
+    ctx = MagicMock(spec=CallbackContext)
+    ctx.agent_name = "hunter"
+    req = MagicMock()
+    req.contents = []
+
+    assert await cb.on_before_model(ctx, req) is None   # turn 1 — allowed
+    blocked = await cb.on_before_model(ctx, req)        # turn 2 — blocked
+    assert isinstance(blocked, LlmResponse)
+
+    cb.reset_turn_counts()
+
+    assert await cb.on_before_model(ctx, req) is None   # turn 1 again — allowed

--- a/AI/trashdig/tests/tools/conftest.py
+++ b/AI/trashdig/tests/tools/conftest.py
@@ -1,6 +1,24 @@
 import pytest
 from unittest.mock import patch
+
+import trashdig.tools.base
 from trashdig.config import Config
+
+
+@pytest.fixture(autouse=True)
+def clear_language_cache():
+    """Clear the tree-sitter language cache before each test.
+
+    Some tests mock _get_ts_language to return a MagicMock, which gets stored
+    in the module-level _LANGUAGE_CACHE.  Without clearing it, that stale mock
+    leaks into subsequent tests that call _make_parser() directly and then fail
+    with TypeError when tree_sitter.Parser receives a MagicMock instead of a
+    real Language object.
+    """
+    trashdig.tools.base._LANGUAGE_CACHE.clear()
+    yield
+    trashdig.tools.base._LANGUAGE_CACHE.clear()
+
 
 @pytest.fixture(autouse=True)
 def mock_cfg():

--- a/AI/trashdig/tests/tools/test_update_hypothesis_status.py
+++ b/AI/trashdig/tests/tools/test_update_hypothesis_status.py
@@ -28,6 +28,10 @@ def test_update_hypothesis_status_delegates_to_pool(tmp_path):
 
 
 def test_update_hypothesis_status_error():
-    res = update_hypothesis_status("task1", "completed",
-                                   db_path="/nonexistent/path/db.db")
+    # Simulate a database error by making get_database raise.  We can't rely
+    # on an invalid path to trigger the error because ProjectDatabase.__init__
+    # calls os.makedirs(), which creates any missing directories.
+    with patch("trashdig.tools.update_hypothesis_status.get_database",
+               side_effect=Exception("disk full")):
+        res = update_hypothesis_status("task1", "completed")
     assert "Error updating database" in res

--- a/AI/trashdig/trashdig.toml
+++ b/AI/trashdig/trashdig.toml
@@ -36,3 +36,42 @@ data_dir = "{workspace}/.trashdig"
 [agents.validator]
 # model = "gemini-2.0-flash"
 # provider = "google"
+
+# ---------------------------------------------------------------------------
+# MCP Server Integrations
+# ---------------------------------------------------------------------------
+# Each [[mcp_servers]] entry wires an external MCP server as a toolset.
+# Tools are prefixed "mcp_<name>_*" to avoid name collisions.
+#
+# Transport options:
+#   "stdio"  — spawn a local process (command + args)
+#   "sse"    — connect to a Server-Sent Events endpoint (url)
+#   "http"   — connect to a Streamable HTTP endpoint (url)
+#
+# Optional keys:
+#   tool_filter = ["tool_a", "tool_b"]   # allow only these tools (default: all)
+#   agents      = ["hunter", "skeptic"]  # restrict to these agents (default: all)
+#   timeout     = 10.0                   # connection timeout in seconds
+#
+# Example: mcp-server-fetch (web page retrieval via MCP)
+# [[mcp_servers]]
+# name      = "fetch"
+# transport = "stdio"
+# command   = "uvx"
+# args      = ["mcp-server-fetch"]
+# agents    = ["hunter", "skeptic"]
+#
+# Example: local CVE lookup MCP server over SSE
+# [[mcp_servers]]
+# name        = "nvd"
+# transport   = "sse"
+# url         = "http://localhost:8765/sse"
+# tool_filter = ["search_cve", "get_cve_details"]
+# agents      = ["hunter"]
+#
+# Example: security advisory MCP server over Streamable HTTP
+# [[mcp_servers]]
+# name      = "ghsa"
+# transport = "http"
+# url       = "http://localhost:9000/mcp"
+# agents    = ["hunter", "skeptic", "validator"]

--- a/AI/trashdig/trashdig.toml
+++ b/AI/trashdig/trashdig.toml
@@ -28,14 +28,32 @@ data_dir = "{workspace}/.trashdig"
 [agents.archaeologist]
 # model = "gemini-2.0-flash"
 # provider = "google"
+# max_turns = 20   # max LLM calls before the agent is force-stopped
+
+[agents.stack_scout]
+# model = "gemini-2.0-flash"
+# provider = "google"
+# max_turns = 20
+
+[agents.web_route_mapper]
+# model = "gemini-2.0-flash"
+# provider = "google"
+# max_turns = 15
 
 [agents.hunter]
 # model = "gemini-2.0-pro-exp-02-05"
 # provider = "google"
+# max_turns = 30
+
+[agents.skeptic]
+# model = "gemini-2.0-flash"
+# provider = "google"
+# max_turns = 10
 
 [agents.validator]
 # model = "gemini-2.0-flash"
 # provider = "google"
+# max_turns = 15
 
 # ---------------------------------------------------------------------------
 # MCP Server Integrations


### PR DESCRIPTION
- Add McpServerConfig dataclass and Config.mcp_servers property to
  parse [[mcp_servers]] entries from trashdig.toml
- New tools/mcp_toolsets.py factory builds McpToolset instances for
  stdio, SSE, and Streamable HTTP transports with per-server agent
  scoping and tool_filter support
- Add extra_tools parameter to all five agent factory functions so
  McpToolset instances can be appended after permission wrapping
- Wire build_mcp_toolsets() into Coordinator.__init__ for each agent
- Document [[mcp_servers]] config with commented examples in trashdig.toml
- Add build_mcp_toolsets to TOOLS_PKG_NON_TOOLS so the registry test
  does not mistake the factory for an agent-attachable tool

Closes TODO: [MEDIUM] Integrate MCP tools via ADK's native MCP support

https://claude.ai/code/session_01NYUcMWEJAecvzSWxf2Ep6f